### PR TITLE
Add an ability to delete rows using CollapsingMergeTree

### DIFF
--- a/dbms/src/DataStreams/CollapsingSortedBlockInputStream.cpp
+++ b/dbms/src/DataStreams/CollapsingSortedBlockInputStream.cpp
@@ -50,11 +50,11 @@ void CollapsingSortedBlockInputStream::insertRows(ColumnPlainPtrs & merged_colum
 			{
 				LOG_INFO(log, "All rows collapsed");
 				++merged_rows;
-				for (size_t i = 0; i < num_columns; ++i)
-					merged_columns[i]->insertFrom(*last_positive.columns[i], last_positive.row_num);
+				//for (size_t i = 0; i < num_columns; ++i)
+				//	merged_columns[i]->insertFrom(*last_positive.columns[i], last_positive.row_num);
 				++merged_rows;
-				for (size_t i = 0; i < num_columns; ++i)
-					merged_columns[i]->insertFrom(*last_negative.columns[i], last_negative.row_num);
+				//for (size_t i = 0; i < num_columns; ++i)
+				//	merged_columns[i]->insertFrom(*last_negative.columns[i], last_negative.row_num);
 			}
 			return;
 		}

--- a/dbms/src/Storages/MergeTree/MergeTreeDataMerger.cpp
+++ b/dbms/src/Storages/MergeTree/MergeTreeDataMerger.cpp
@@ -570,8 +570,8 @@ MergeTreeData::MutableDataPartPtr MergeTreeDataMerger::mergePartsToTemporaryPart
 	new_data_part->index.swap(to.getIndex());
 
 	/// Для удобства, даже CollapsingSortedBlockInputStream не может выдать ноль строк.
-	if (0 == to.marksCount())
-		throw Exception("Empty part after merge", ErrorCodes::LOGICAL_ERROR);
+	//if (0 == to.marksCount())
+	//	throw Exception("Empty part after merge", ErrorCodes::LOGICAL_ERROR);
 
 	new_data_part->size = to.marksCount();
 	new_data_part->modification_time = time(0);


### PR DESCRIPTION
If we have exactly two rows with different signs each, collapse them instead of keeping them.

E.g.

```
CREATE TABLE IF NOT EXISTS test.test (
    sign Int8,
    event_date Date DEFAULT toDate(event_time),
    event_time DateTime DEFAULT now(),
    session_id UInt32,
    search_phrase String
) ENGINE = CollapsingMergeTree(event_date, (session_id), 8192, sign);

INSERT INTO test.test (sign, session_id, search_phrase) VALUES
(1, 100, 'Yandex');

INSERT INTO test.test (sign, session_id, search_phrase) VALUES
( 1, 101, 'Google');

INSERT INTO test.test (sign, session_id, search_phrase) VALUES
( -1, 101, 'Google');

OPTIMIZE TABLE test.test;

SELECT * FROM test.test; -- Should return only one row!
```

Known bug: a partition should have at least one record before it’s possible to delete rows. Using the example above:

```
CREATE TABLE IF NOT EXISTS test.test (
...
) ENGINE = CollapsingMergeTree(event_date, (session_id), 8192, sign)
;

INSERT INTO test.test (sign, session_id, search_phrase) VALUES
( 1, 101, 'Google');

INSERT INTO test.test (sign, session_id, search_phrase) VALUES
( -1, 101, 'Google');

OPTIMIZE TABLE test.test; -- Whoops! **<Error> void DB::BlockIO::onException(): Poco::Exception. Code: 1000, e.code() = 2, e.displayText() = File not found: /opt/clickhouse/data/test/test0/tmp_20160816_20160816_2_4_1, e.what() = File not found**

SELECT * FROM test.test; -- Still returns 2 rows…
```

This is not properly tested and not ready for production use!
